### PR TITLE
TempFix : Make addtag and deletetag keep current list, jump to index of edited person, and let person panel show tag updates in real time

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTagCommand.java
@@ -1,14 +1,15 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import seedu.address.commons.core.EventsCenter;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
+import seedu.address.commons.events.ui.JumpToListRequestEvent;
 import seedu.address.commons.exceptions.DuplicateDataException;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.person.Address;
@@ -77,7 +78,7 @@ public class AddTagCommand extends UndoableCommand {
         } catch (PersonNotFoundException pnfe) {
             throw new AssertionError("The target person cannot be missing");
         }
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        EventsCenter.getInstance().post(new JumpToListRequestEvent(index));
         return new CommandResult(String.format(MESSAGE_ADD_TAG_SUCCESS, editedPerson));
     }
     /**

--- a/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
@@ -1,14 +1,15 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import seedu.address.commons.core.EventsCenter;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
+import seedu.address.commons.events.ui.JumpToListRequestEvent;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Birthday;
@@ -76,7 +77,8 @@ public class DeleteTagCommand extends UndoableCommand {
         } catch (PersonNotFoundException pnfe) {
             throw new AssertionError("The target person cannot be missing");
         }
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        EventsCenter.getInstance().post(new JumpToListRequestEvent(index));
+
         return new CommandResult(String.format(MESSAGE_DELETE_TAG_SUCCESS, editedPerson));
     }
     /**

--- a/src/main/java/seedu/address/model/person/AddressContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/AddressContainsKeywordsPredicate.java
@@ -34,6 +34,6 @@ public class AddressContainsKeywordsPredicate extends FieldContainsKeywordsPredi
 
     @Override
     public Comparator<ReadOnlyPerson> sortOrderComparator() {
-        return (person1, person2) -> (0); //no sorting for address
+        return defaultSortOrder; //no sorting for address
     }
 }

--- a/src/main/java/seedu/address/model/person/BirthdayContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/BirthdayContainsKeywordsPredicate.java
@@ -34,6 +34,6 @@ public class BirthdayContainsKeywordsPredicate extends FieldContainsKeywordsPred
 
     @Override
     public Comparator<ReadOnlyPerson> sortOrderComparator() {
-        return (person1, person2) -> (0); //no sorting for birthday
+        return defaultSortOrder; //no sorting for birthday
     }
 }

--- a/src/main/java/seedu/address/model/person/EmailContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/EmailContainsKeywordsPredicate.java
@@ -34,6 +34,6 @@ public class EmailContainsKeywordsPredicate extends FieldContainsKeywordsPredica
 
     @Override
     public Comparator<ReadOnlyPerson> sortOrderComparator() {
-        return (person1, person2) -> (0); //no sorting for email
+        return defaultSortOrder; //no sorting for email
     }
 }

--- a/src/main/java/seedu/address/model/person/FieldContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/FieldContainsKeywordsPredicate.java
@@ -10,8 +10,10 @@ import java.util.function.Predicate;
  *  Represents a predicate for a field of a ReadOnlyPerson with the ability to test an instance of a ReadOnlyPerson.
  */
 public abstract class FieldContainsKeywordsPredicate implements Predicate<ReadOnlyPerson> {
+    protected static Comparator<ReadOnlyPerson> defaultSortOrder = null;
     protected List<String> keywords;
     protected String fieldToSearch;
+
 
     /**
      * Returns an immutable List of keywords that is used to evaluate a ReadOnlyPerson.

--- a/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
@@ -34,6 +34,6 @@ public class PhoneContainsKeywordsPredicate extends FieldContainsKeywordsPredica
 
     @Override
     public Comparator<ReadOnlyPerson> sortOrderComparator() {
-        return (person1, person2) -> (0); //no sorting for phone
+        return defaultSortOrder; //no sorting for phone
     }
 }

--- a/src/main/java/seedu/address/model/person/TagListContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/TagListContainsKeywordsPredicate.java
@@ -42,6 +42,6 @@ public class TagListContainsKeywordsPredicate extends FieldContainsKeywordsPredi
 
     @Override
     public Comparator<ReadOnlyPerson> sortOrderComparator() {
-        return (person1, person2) -> (0); //no sorting for tag
+        return defaultSortOrder; //no sorting for tag
     }
 }

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -61,6 +61,7 @@ public class PersonListPanel extends UiPart<Region> {
     private void scrollTo(int index) {
         Platform.runLater(() -> {
             personListView.scrollTo(index);
+            personListView.getSelectionModel().clearSelection();
             personListView.getSelectionModel().clearAndSelect(index);
         });
     }

--- a/src/test/java/seedu/address/logic/commands/AddTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddTagCommandTest.java
@@ -68,6 +68,7 @@ public class AddTagCommandTest {
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.updatePerson(model.getFilteredPersonList().get(0), editedPerson);
+        showFirstPersonOnly(expectedModel);
 
         assertCommandSuccess(addTagCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/DeleteTagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteTagCommandTest.java
@@ -68,6 +68,7 @@ public class DeleteTagCommandTest {
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.updatePerson(model.getFilteredPersonList().get(0), editedPerson);
+        showFirstPersonOnly(expectedModel);
 
         assertCommandSuccess(deleteTagCommand, model, expectedMessage, expectedModel);
     }


### PR DESCRIPTION
 - As part of the changes, the default sort for all the predicates was made to be null to preserve list order when using addtag or deletetag